### PR TITLE
fix: remove unavailable web3 identifiers when local agent gets rebuilt

### DIFF
--- a/packages/agent-explore/src/context/web3/VeramoWeb3Provider.tsx
+++ b/packages/agent-explore/src/context/web3/VeramoWeb3Provider.tsx
@@ -44,14 +44,14 @@ export const VeramoWeb3Provider = ({
         name: 'walletconnect',
       })
     }
-    void createWeb3Agent({ connectors }).then(setWeb3Agent)
-    queryClient.invalidateQueries({ 
-      queryKey: [
-        'identifiers', 
-        { agentId: 'web3Agent'}
-      ] 
+    void createWeb3Agent({ connectors }).then(setWeb3Agent).then(() => {
+      queryClient.invalidateQueries({ 
+        queryKey: [
+          'identifiers', 
+          { agentId: 'web3Agent'}
+        ] 
+      })
     })
-    console.log('invalidateQueries')
     return () => {
       setWeb3Agent(undefined)
     }

--- a/packages/agent-explore/src/context/web3/web3Agent.ts
+++ b/packages/agent-explore/src/context/web3/web3Agent.ts
@@ -181,8 +181,6 @@ export async function createWeb3Agent({ connectors }: {
     ],
   })
 
-  // commented out in https://github.com/veramolabs/agent-explorer/pull/115/files
-  // was causing locally-managed X25519 keys to be deleted on page refresh
   const identifiers = await agent.didManagerFind()
   const markedForClearance = new Set<string>([])
   for (const identifier of identifiers) {

--- a/packages/agent-explore/src/context/web3/web3Agent.ts
+++ b/packages/agent-explore/src/context/web3/web3Agent.ts
@@ -193,7 +193,6 @@ export async function createWeb3Agent({ connectors }: {
 
   for (const info of connectors) {
     if (info.accounts) {
-      console.log('nana')
       for (const account of info.accounts) {
         for (const provider of ['pkh', 'ethr']) {
           const prefix = (provider === 'pkh') ? 'did:pkh:eip155:' : 'did:ethr:0x'

--- a/packages/agent-explore/src/plugins/identifiers/ManagedIdentifiers.tsx
+++ b/packages/agent-explore/src/plugins/identifiers/ManagedIdentifiers.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react'
 import { Table, Button, Row, Space, App, Drawer } from 'antd'
 import { Link } from 'react-router-dom'
-import { useQuery } from 'react-query'
+import { useQuery, useQueryClient } from 'react-query'
 import { useVeramo } from '@veramo-community/veramo-react'
 import { PageContainer, ProList } from '@ant-design/pro-components'
 import { IDIDManager } from '@veramo/core-types'
@@ -12,13 +12,15 @@ import {
 } from './NewIdentifierForm'
 import { shortId, IdentifierProfile } from '@veramo-community/agent-explorer-plugin'
 import { createMediateRequestMessage } from '@veramo/did-comm'
-import { DeleteOutlined, CopyOutlined, PlusOutlined } from '@ant-design/icons'
-import { IDataStore, IIdentifier } from '@veramo/core'
+import { DeleteOutlined, PlusOutlined } from '@ant-design/icons'
+import { IDataStore } from '@veramo/core'
 
 export const ManagedIdentifiers = () => {
   const { notification } = App.useApp()
   const { agent } = useVeramo<IDIDManager & IDataStore>()
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const [ creating, setCreating ] = useState(false)
+  const queryClient = useQueryClient()
 
   const { data: providers } = useQuery(
     ['providers', { agentId: agent?.context.id }],
@@ -31,6 +33,7 @@ export const ManagedIdentifiers = () => {
 
     const handleNewIdentifierOk = async (values: NewIdentifierFormValues) => {
       setDrawerOpen(false)
+      setCreating(true)
       const { alias, provider } = values
       let options = undefined
       if (provider === 'did:peer') {
@@ -106,8 +109,13 @@ export const ManagedIdentifiers = () => {
 
       }
   
-      
-      refetch()
+      queryClient.invalidateQueries({ 
+        queryKey: [
+          'identifiers', 
+          { agentId: 'web3Agent'}
+        ] 
+      })
+      setCreating(false)
     }
 
   return (
@@ -118,6 +126,7 @@ export const ManagedIdentifiers = () => {
             icon={<PlusOutlined />}
             type="primary"
             title="Create new identifier"
+            loading={creating}
             onClick={() => setDrawerOpen(true)}
           >New</Button>,
         ]}

--- a/packages/agent-explore/src/plugins/identifiers/NewIdentifierForm.tsx
+++ b/packages/agent-explore/src/plugins/identifiers/NewIdentifierForm.tsx
@@ -72,7 +72,6 @@ export const NewIdentifierForm: React.FC<NewIdentifierFormFormProps> = ({
       .then((values) => {
         form.resetFields()
         setStep(0)
-        console.log({values})
         onNewIdentifier(values)
       })
       .catch((info) => {


### PR DESCRIPTION
This makes the local agent only show the web3 DIDs that are actually available, but there is still some race-condition in the ManagedIdentifiers page